### PR TITLE
Sec fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Optional spaCy support:
 pip install shadow_data[spacy]
 ```
 
-spaCy models are downloaded automatically at runtime when needed. To install manually:
+spaCy models must be installed before use:
 
 ```bash
 python -m spacy download en_core_web_trf
@@ -57,7 +57,7 @@ symmetric = Symmetric()
 key = symmetric.create_key()
 ciphertext = symmetric.encrypt("hello")
 plaintext = symmetric.decrypt(ciphertext)
-print(key, ciphertext, plaintext)
+print(ciphertext, plaintext)
 ```
 
 ## Docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,5 +9,5 @@ This folder provides focused guides for the current feature set.
 
 ## Quick pointers
 - PII detection is optional and requires the `shadow_data[spacy]` extra.
-- spaCy models download at runtime when first used.
+- spaCy models must be installed before use. Runtime downloads are opt-in.
 - Masking and reversible transforms are planned but not yet implemented.

--- a/docs/cryptography.md
+++ b/docs/cryptography.md
@@ -13,7 +13,6 @@ key = symmetric.create_key()
 ciphertext = symmetric.encrypt("Hello World!")
 plaintext = symmetric.decrypt(ciphertext)
 
-print(key)
 print(ciphertext)
 print(plaintext)
 ```
@@ -37,3 +36,5 @@ print(plaintext)
 ## Error handling
 - `CipherKeyNotFoundError`: raised when encrypting or decrypting without a key.
 - `InvalidCipherKeyError`: raised when setting an invalid Fernet key.
+
+Do not write encryption keys to logs or console output in production systems.

--- a/docs/pii.md
+++ b/docs/pii.md
@@ -27,5 +27,5 @@ print(entities)
 
 ## Notes
 - The model name is assembled as `{lang}_{core}_{size}` (for example, `en_core_web_sm`).
-- Models are downloaded automatically on first use if missing.
+- Models must be installed before use. Pass `auto_download=True` only in trusted setup flows where runtime package installation is acceptable.
 - Returned entities are filtered to these labels: `PER`, `LOC`, `ORG`, `MISC`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,7 +3,7 @@
 This guide covers the anonymization helpers and localized identifiers.
 
 ## Text replacement
-`TextProcessor.replace_text` uses regular expressions for matching and replacement.
+`TextProcessor.replace_text` treats the search term as literal text. Use `TextProcessor.replace_regex` when a regular expression is required.
 
 ```python
 from shadow_data.anonymization import TextProcessor

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -8,12 +8,12 @@ from shadow_data.cryptohash.symmetric_cipher import Symmetric
 from shadow_data.l10n.brazil import IdentifierAnonymizer as BrazilIdentifierAnonymizer
 from shadow_data.l10n.usa import IdentifierAnonymizer as UsaIdentifierAnonymizer
 
-text = "Contact me at user@example.com or 415-555-0199. Server: 10.0.0.1"
+text = 'Contact me at user@example.com or 415-555-0199. Server: 10.0.0.1'
 
 anonymized_text = Ipv4Anonymization.anonymize_ipv4(text)
-anonymized_text = TextProcessor.replace_text("Contact", "Reach", anonymized_text)
-email = EmailAnonymization.anonymize_email("user@example.com")
-phone = PhoneNumberAnonymization.anonymize_phone_number("415-555-0199")
+anonymized_text = TextProcessor.replace_text('Contact', 'Reach', anonymized_text)
+email = EmailAnonymization.anonymize_email('user@example.com')
+phone = PhoneNumberAnonymization.anonymize_phone_number('415-555-0199')
 
 print(anonymized_text)
 print(email)
@@ -24,7 +24,7 @@ ssn_anonymizer = UsaIdentifierAnonymizer(ssn_text)
 ssn_anonymizer.anonymize()
 print(ssn_anonymizer.cleaned_content)
 
-cpf = "806.846.761-09"
+cpf = '806.846.761-09'
 cpf_anonymizer = BrazilIdentifierAnonymizer(cpf)
 cpf_anonymizer.anonymize()
 print(cpf_anonymizer.cleaned_content)
@@ -32,9 +32,8 @@ print(cpf_anonymizer.cleaned_content)
 symmetric = Symmetric()
 key = symmetric.create_key()
 
-ciphertext = symmetric.encrypt("hello")
+ciphertext = symmetric.encrypt('hello')
 plaintext = symmetric.decrypt(ciphertext)
 
-print(key)
 print(ciphertext)
 print(plaintext)

--- a/examples/symmetric_cipher.md
+++ b/examples/symmetric_cipher.md
@@ -9,7 +9,6 @@ This simple encryption and decryption method uses symmetric cryptography. Users 
 from shadow_data.cryptohash.symmetric_cipher import Symmetric
 symmetric = Symmetric()
 key = symmetric.create_key() # Generate a new key. It can be saved at a safe place to be used later
-print(f"Key: {key}")
 
 
 content = "Hello World!"
@@ -21,7 +20,6 @@ print(f"Decrypted: {decrypted_content}")
 ```
 ### Results
 ```plain
-Key: b'bpSGcODTJ1iOwxloIQJrAiYDRaqyypdCsQfg1EwVOTc='
 Encrypted: b'gAAAAABnDAexPmKZ0Bh9U4KH7iv_OsHQ1p2ijjJjdHYbagZ-xdyWRT5ChcAw_gVSwfPhE-HG4aZd2xG02123UPTVeJm3nSTF0w=='
 Decrypted: Hello World!
 ```
@@ -36,13 +34,13 @@ symmetric.cipher_key = key
 content = "Hello World"
 encrypted = symmetric.encrypt(content)
 decrypted = symmetric.decrypt(encrypted)
-print(f"Encrypted using key {key}: {encrypted}")
-print(f"Decrypted using key {key}: {decrypted}")
+print(f"Encrypted: {encrypted}")
+print(f"Decrypted: {decrypted}")
 
 ```
 
 ### Results:
 ```
-Encrypted using key b'bpSGcODTJ1iOwxloIQJrAiYDRaqyypdCsQfg1EwVOTc=': b'gAAAAABnDAi8t8YvtEPlmdtvwL5t-P31db82r49yjIfX-HhQGxK0Sd3_IpxrvD3PiajyOSm835OpfcXFQ1kHkAlt1EzqXNBInA=='
-Decrypted using key b'bpSGcODTJ1iOwxloIQJrAiYDRaqyypdCsQfg1EwVOTc=': Hello World
+Encrypted: b'gAAAAABnDAi8t8YvtEPlmdtvwL5t-P31db82r49yjIfX-HhQGxK0Sd3_IpxrvD3PiajyOSm835OpfcXFQ1kHkAlt1EzqXNBInA=='
+Decrypted: Hello World
 ```

--- a/shadow_data/anonymization.py
+++ b/shadow_data/anonymization.py
@@ -6,13 +6,17 @@ from shadow_data.exceptions import InvalidEmailError
 class TextProcessor:
     @staticmethod
     def replace_text(original_term: str, to_replace: str, original_content: str) -> str:
-        return re.sub(original_term, to_replace, original_content)
+        return re.sub(re.escape(original_term), lambda _: to_replace, original_content)
+
+    @staticmethod
+    def replace_regex(pattern: str, to_replace: str, original_content: str) -> str:
+        return re.sub(pattern, to_replace, original_content)
 
 
 class Ipv4Anonymization:
     @staticmethod
     def anonymize_ipv4(text: str, pattern: str = r'\1.X.X.X') -> str:
-        return TextProcessor.replace_text(r'\b(\d{1,3})(\.\d{1,3}){3}\b', pattern, text)
+        return TextProcessor.replace_regex(r'\b(\d{1,3})(\.\d{1,3}){3}\b', pattern, text)
 
 
 class EmailAnonymization:

--- a/shadow_data/cryptohash/symmetric_cipher.py
+++ b/shadow_data/cryptohash/symmetric_cipher.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 class Symmetric:
     def __init__(self, cipher_key: Optional[bytes] = None):
+        if cipher_key is not None:
+            self._validate_cipher_key(cipher_key)
         self._cipher_key = cipher_key
 
     def create_key(self) -> bytes:

--- a/shadow_data/l10n/brazil.py
+++ b/shadow_data/l10n/brazil.py
@@ -14,7 +14,7 @@ class IdentifierAnonymizer(ClearIdentifier):
             raise ValueError('Invalid identifier length')
 
     def _anonymize_cpf(self, content: str):
-        self.cleaned_content = TextProcessor.replace_text(r'(\d{2})(\d{9})', r'\1*********', content)
+        self.cleaned_content = TextProcessor.replace_regex(r'(\d{2})(\d{9})', r'\1*********', content)
 
     def _anonymize_cnpj(self, content: str):
-        self.cleaned_content = TextProcessor.replace_text(r'(\d{2})(\d{12})', r'\1************', content)
+        self.cleaned_content = TextProcessor.replace_regex(r'(\d{2})(\d{12})', r'\1************', content)

--- a/shadow_data/l10n/usa.py
+++ b/shadow_data/l10n/usa.py
@@ -5,5 +5,11 @@ from shadow_data.l10n.ClearIdentifier import ClearIdentifier
 
 class IdentifierAnonymizer(ClearIdentifier):
     def anonymize(self):
-        ssn_pattern = r'\b(\d{3})-(\d{2})-(\d{4})\b'
-        self.cleaned_content = re.sub(ssn_pattern, r'XXX-XX-\3', self.content_to_anonymize)
+        ssn_pattern = r'(?<!\d)(\d{3})([- ]?)(\d{2})([- ]?)(\d{4})(?!\d)'
+        self.cleaned_content = re.sub(ssn_pattern, self._mask_ssn, self.content_to_anonymize)
+
+    @staticmethod
+    def _mask_ssn(match: re.Match) -> str:
+        first_separator = match.group(2)
+        second_separator = match.group(4)
+        return f'XXX{first_separator}XX{second_separator}{match.group(5)}'

--- a/shadow_data/pii/spacy.py
+++ b/shadow_data/pii/spacy.py
@@ -1,5 +1,6 @@
 import spacy
 import subprocess
+import sys
 
 from spacy.language import Language
 
@@ -8,7 +9,7 @@ from shadow_data.pii.enums import ModelLang, ModelCore, ModelSize
 
 class ModelSelector:
     @staticmethod
-    def select(lang: ModelLang, core: ModelCore, size: ModelSize) -> Language:
+    def select(lang: ModelLang, core: ModelCore, size: ModelSize, auto_download: bool = False) -> Language:
         """
         Loads a spaCy model by combining language, core news, and size.
 
@@ -34,8 +35,13 @@ class ModelSelector:
         try:
             nlp = spacy.load(model_name)
         except OSError:
+            if not auto_download:
+                raise RuntimeError(
+                    f'Model {model_name} is not installed. Install it with: '
+                    f'{sys.executable} -m spacy download {model_name}'
+                )
             try:
-                subprocess.run(['python', '-m', 'spacy', 'download', model_name], check=True)
+                subprocess.run([sys.executable, '-m', 'spacy', 'download', model_name], check=True)
                 nlp = spacy.load(model_name)
             except subprocess.CalledProcessError:
                 raise RuntimeError(f'Could not download and load model {model_name}')
@@ -43,14 +49,16 @@ class ModelSelector:
 
 
 class SensitiveData:
-    def set_model(self, model_lang: ModelLang, model_core: ModelCore, model_size: ModelSize) -> Language:
+    def set_model(
+        self, model_lang: ModelLang, model_core: ModelCore, model_size: ModelSize, auto_download: bool = False
+    ) -> Language:
         model_selector = ModelSelector()
-        return model_selector.select(model_lang, model_core, model_size)
+        return model_selector.select(model_lang, model_core, model_size, auto_download=auto_download)
 
     def identify_sensitive_data(
-        self, model_lang: ModelLang, model_core: ModelCore, model_size: ModelSize, content
+        self, model_lang: ModelLang, model_core: ModelCore, model_size: ModelSize, content, auto_download: bool = False
     ) -> list:
-        nlp = self.set_model(model_lang, model_core, model_size)
+        nlp = self.set_model(model_lang, model_core, model_size, auto_download=auto_download)
         doc = nlp(content)
 
         sensitive_data = []

--- a/tests/cryptohash/test_symmetric_cipher.py
+++ b/tests/cryptohash/test_symmetric_cipher.py
@@ -5,6 +5,11 @@ from shadow_data.cryptohash.symmetric_cipher import Symmetric
 
 
 class TestSymmetric:
+    def test_init_with_valid_cipher_key(self):
+        key = Fernet.generate_key()
+        symmetric = Symmetric(key)
+        assert symmetric.cipher_key == key
+
     def test_create_key(self):
         symmetric = Symmetric()
         key = symmetric.create_key()

--- a/tests/i10n/test_usa.py
+++ b/tests/i10n/test_usa.py
@@ -36,3 +36,17 @@ class TestIdentifierAnonymizer:
         anonymizer = IdentifierAnonymizer(content)
         anonymizer.anonymize()
         assert anonymizer.cleaned_content == expected_output
+
+    def test_anonymize_ssn_with_spaces(self):
+        content = 'SSN is 123 45 6789.'
+        expected_output = 'SSN is XXX XX 6789.'
+        anonymizer = IdentifierAnonymizer(content)
+        anonymizer.anonymize()
+        assert anonymizer.cleaned_content == expected_output
+
+    def test_anonymize_compact_ssn(self):
+        content = 'SSN is 123456789.'
+        expected_output = 'SSN is XXXXX6789.'
+        anonymizer = IdentifierAnonymizer(content)
+        anonymizer.anonymize()
+        assert anonymizer.cleaned_content == expected_output

--- a/tests/pii/test_pii_spacy.py
+++ b/tests/pii/test_pii_spacy.py
@@ -1,11 +1,15 @@
-import pytest
+import subprocess
+import sys
 from unittest.mock import patch, MagicMock
 
-from spacy import Language
+import pytest
 
-from shadow_data.pii.enums import ModelLang, ModelCore, ModelSize
-from shadow_data.pii.spacy import ModelSelector, SensitiveData
-import subprocess
+pytest.importorskip('spacy')
+
+from spacy import Language  # noqa: E402
+
+from shadow_data.pii.enums import ModelLang, ModelCore, ModelSize  # noqa: E402
+from shadow_data.pii.spacy import ModelSelector, SensitiveData  # noqa: E402
 
 
 class TestModelSelector:
@@ -53,13 +57,24 @@ class TestModelSelector:
             core = ModelCore.NEWS
             size = ModelSize.SMALL
 
-            nlp = ModelSelector.select(lang, core, size)
+            nlp = ModelSelector.select(lang, core, size, auto_download=True)
 
             mock_subprocess_run.assert_called_once_with(
-                ['python', '-m', 'spacy', 'download', 'en_core_news_sm'], check=True
+                [sys.executable, '-m', 'spacy', 'download', 'en_core_news_sm'], check=True
             )
             assert mock_spacy_load.call_count == 2
             assert isinstance(nlp, MagicMock)
+
+    def test_select_model_missing_without_auto_download(self):
+        with patch('spacy.load', side_effect=OSError), patch('subprocess.run') as mock_subprocess_run:
+            lang = ModelLang.ENGLISH
+            core = ModelCore.NEWS
+            size = ModelSize.SMALL
+
+            with pytest.raises(RuntimeError, match='is not installed'):
+                ModelSelector.select(lang, core, size)
+
+            mock_subprocess_run.assert_not_called()
 
     def test_select_model_download_failure(self):
         with patch('spacy.load', side_effect=OSError), patch(
@@ -70,10 +85,10 @@ class TestModelSelector:
             size = ModelSize.SMALL
 
             with pytest.raises(RuntimeError):
-                ModelSelector.select(lang, core, size)
+                ModelSelector.select(lang, core, size, auto_download=True)
 
             mock_subprocess_run.assert_called_once_with(
-                ['python', '-m', 'spacy', 'download', 'en_core_news_sm'], check=True
+                [sys.executable, '-m', 'spacy', 'download', 'en_core_news_sm'], check=True
             )
 
 
@@ -95,7 +110,7 @@ class TestSensitiveData:
         ]
         mock_nlp.return_value = mock_doc
 
-        monkeypatch.setattr(SensitiveData, 'set_model', lambda self, *args: mock_nlp)
+        monkeypatch.setattr(SensitiveData, 'set_model', lambda self, *args, **kwargs: mock_nlp)
         return mock_nlp
 
     @pytest.fixture
@@ -105,7 +120,7 @@ class TestSensitiveData:
         mock_doc.ents = []
         mock_nlp.return_value = mock_doc
 
-        monkeypatch.setattr(SensitiveData, 'set_model', lambda self, *args: mock_nlp)
+        monkeypatch.setattr(SensitiveData, 'set_model', lambda self, *args, **kwargs: mock_nlp)
         return mock_nlp
 
     def test_identify_sensitive_data(self, sensitive_data_instance, mock_nlp):
@@ -153,5 +168,5 @@ class TestSensitiveData:
 
             result = sensitive_data.set_model(model_lang, model_core, model_size)
 
-            model_selector_mock.select.assert_called_once_with(model_lang, model_core, model_size)
+            model_selector_mock.select.assert_called_once_with(model_lang, model_core, model_size, auto_download=False)
             assert result == expected_language

--- a/tests/pii/test_pii_spacy.py
+++ b/tests/pii/test_pii_spacy.py
@@ -1,12 +1,24 @@
 import subprocess
 import sys
+import types
 from unittest.mock import patch, MagicMock
 
 import pytest
 
-pytest.importorskip('spacy')
+if 'spacy' not in sys.modules:
+    spacy_stub = types.ModuleType('spacy')
+    spacy_language_stub = types.ModuleType('spacy.language')
 
-from spacy import Language  # noqa: E402
+    class Language:
+        pass
+
+    spacy_stub.load = MagicMock()
+    spacy_language_stub.Language = Language
+
+    sys.modules['spacy'] = spacy_stub
+    sys.modules['spacy.language'] = spacy_language_stub
+
+from spacy.language import Language  # noqa: E402
 
 from shadow_data.pii.enums import ModelLang, ModelCore, ModelSize  # noqa: E402
 from shadow_data.pii.spacy import ModelSelector, SensitiveData  # noqa: E402

--- a/tests/test_text_processor.py
+++ b/tests/test_text_processor.py
@@ -37,3 +37,17 @@ class TestTextProcessor:
         expected_output = 'ANONYMOUS bought a car. João sold a house.'
 
         assert TextProcessor.replace_text(original_term, to_replace, original_content) == expected_output
+
+    def test_replace_text_treats_term_as_literal(self):
+        original_content = 'User a+b@example.com and user axb@example.com'
+        original_term = 'a+b@example.com'
+        to_replace = 'ANONYMOUS'
+
+        expected_output = 'User ANONYMOUS and user axb@example.com'
+
+        assert TextProcessor.replace_text(original_term, to_replace, original_content) == expected_output
+
+    def test_replace_regex_supports_patterns(self):
+        original_content = 'IDs are 123 and 456.'
+
+        assert TextProcessor.replace_regex(r'\d+', 'X', original_content) == 'IDs are X and X.'


### PR DESCRIPTION
 - TextProcessor.replace_text() now treats search text literally, preventing regex-based redaction bypass/ReDoS risk.
  - Added TextProcessor.replace_regex() and moved internal regex callers to it.
  - spaCy model downloads are now opt-in with auto_download=True; default behavior fails with install guidance.
  - spaCy download path now uses sys.executable instead of bare python.
  - US SSN masking now handles hyphenated, spaced, and compact SSNs.
  - Symmetric(cipher_key=...) now validates constructor-provided keys immediately.
  - Docs/examples no longer print encryption keys.
  - Optional spaCy tests now skip cleanly when the optional extra is not installed.