### PR TITLE
Add manual documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,7 @@
 name: Documentation
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## What changed

- add a manual `workflow_dispatch` trigger to the documentation workflow

## Why

The first Pages deployment needs a reliable manual trigger, and future deploys can be retried without creating an empty commit.

## Impact

Normal pushes and pull requests continue to build the documentation as before. Repository maintainers also get a **Run workflow** action.

## Validation

- `poetry run mkdocs build --strict`
- `git diff --check`
